### PR TITLE
fix #10 headers path for cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ install(
 
 # Header files are copied to the install directory
 install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tau
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tau
     DESTINATION include
 )
 


### PR DESCRIPTION
There's no 'include/tau' subdirectory (all headers are in 'tau' directory instead), so 'make install' is repaired by this change in my environment.