### PR TITLE
Only use red text for FAILED summary if tests failed

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -1175,7 +1175,8 @@ inline int tau_main(int argc, char** argv) {
     tauColouredPrintf(TAU_COLOUR_BRIGHTGREEN_, "[  PASSED  ] %" TAU_PRIu64 " %s\n", 
                             tauStatsTestsRan - tauStatsNumTestsFailed,
                             tauStatsTestsRan - tauStatsNumTestsFailed == 1 ? "suite" : "suites");
-    tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, "[  FAILED  ] %" TAU_PRIu64 " %s\n", 
+    tauColouredPrintf(tauStatsNumTestsFailed > 0 ? TAU_COLOUR_BRIGHTRED_ : TAU_COLOUR_DEFAULT_,
+                            "[  FAILED  ] %" TAU_PRIu64 " %s\n",
                             tauStatsNumTestsFailed, 
                             tauStatsNumTestsFailed == 1 ? "suite" : "suites");
 


### PR DESCRIPTION
### What this changes?
This change causes the FAILED summary text to be displayed with red coloration only if there were failed tests. Otherwise use the default text coloration (light gray). Other unit testing frameworks (GTest, DocTest) follow this convention.

### Motivation
I find it slightly distracting and confusing to see the red "FAILED" text in the test summary when all tests have passed, with zero failures. I only expect to see red text in the console output from a unit test framework in the event that there were test failures.

### Comparisons
1. Tau
![image](https://user-images.githubusercontent.com/10336413/150658888-d0157d1e-1135-4a75-aac0-00f66eae29c7.png)

2. Google Test
![image](https://user-images.githubusercontent.com/10336413/150658860-0693fb95-7e8d-4171-a93b-89edb1f0a9b5.png)

3. DocTest
![image](https://user-images.githubusercontent.com/10336413/150658848-de4df624-709b-4e67-ade9-58851147bcfe.png)

