### PR TITLE
fix tauClock msan false positive on linux

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -253,7 +253,7 @@ static inline double tauClock() {
     return TAU_CAST(double, clock()) * 1000000000 / CLOCKS_PER_SEC; // in nanoseconds
 
 #elif defined(__linux)
-    struct timespec ts;
+    struct timespec ts = {0, 0};
     #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
         timespec_get(&ts, TIME_UTC);
     #else


### PR DESCRIPTION
When running a test with memory sanitizer on Linux, a false positive occurs because ts is not initialized.

Minimal example to reproduce (compile with MSan enabled):
```c
#include <tau/tau.h>

TEST(example, some_test) {
  REQUIRE_EQ(1, 1);
}

TAU_MAIN()
```