### PR TITLE
CI fix: Use fixed mingw version when building for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,9 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
+        uses: egor-tensin/setup-mingw@v2.2.0
         with:
           platform: ${{ matrix.architecture }}
+          version: 12.2.0
 
       - name: CMake
         run: |


### PR DESCRIPTION
This should fix the CI builds for Windows that has been failing for quite some time with the following error message:

```
Cannot find path
'... lib\mingw\tools\install\mingw64\x86_64-w64-mingw32\lib\libpthread.dll.a'
```

By upgrading the `egor-tensin/setup-mingw` from version `v2` to `v2.2.0` we are able to specify a specific mingw version.

A too new version of mingw, for example 13.2.0, seems to fail the build for us. So let's use the fixed version 12.2.0 which was working fine before.

This solution is suggested for example here:
https://github.com/egor-tensin/setup-mingw/issues/17#issuecomment-1890253793