### PR TITLE
 CI fix: Use version 20.04 when building with clang for Ubuntu

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
 
 
   Clang:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         build_type: [Debug, RelWithDebInfo, MinSizeRel, Release] 


### PR DESCRIPTION
This fixes the problem that `clang-10` is not available for newer versions of
Ubuntu. Of course we could upgrade `clang` as well, but let's restore the
functionality as it was, and after that, we can introduce new changes.
    
By using a fixed version we get a more controlled build environment.