### PR TITLE
Add dedicated macros for pointer comparisons

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -659,6 +659,33 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
     tauColouredPrintf(TAU_COLOUR_CYAN_,">");
 }
 
+#define __TAUCMP_PTR__(actual, expected, cond, space, macroName, failOrAbort)                                   \
+    do {                                                                                                        \
+        if(!((void*)(actual)cond(void*)(expected))) {                                                           \
+            tauPrintf("%s:%u: ", __FILE__, __LINE__);                                                           \
+            tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, "FAILED\n");                                               \
+            if(tauShouldDecomposeMacro(#actual, #expected, 0)) {                                                \
+                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "  In macro : ");                                     \
+                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "%s( %s, %s )\n",                                     \
+                                                            #macroName,                                         \
+                                                            #actual, #expected);                                \
+            }                                                                                                   \
+            tauPrintf("  Expected : %s", #actual);                                                              \
+            printf(" %s ", #cond space);                                                                        \
+            printf("%p", (void*)expected);                                                                      \
+            tauPrintf("\n");                                                                                    \
+                                                                                                                \
+            tauPrintf("    Actual : %s", #actual);                                                              \
+            printf(" == ");                                                                                     \
+            printf("%p", (void*)actual);                                                                        \
+            tauPrintf("\n");                                                                                    \
+            failOrAbort;                                                                                        \
+            if(shouldAbortTest) {                                                                               \
+                return;                                                                                         \
+            }                                                                                                   \
+        }                                                                                                       \
+    }                                                                                                           \
+    while(0)
 
 #define __TAUCMP_BUF__(actual, expected, len, cond, ifCondFailsThenPrint, actualPrint, macroName, failOrAbort)  \
     do {                                                                                                        \
@@ -767,6 +794,12 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
 #define CHECK_BUF_NE(actual, expected, n)       __TAUCMP_BUF__(actual, expected, n, ==, !=, equal, CHECK_BUF_NE, TAU_FAIL_IF_INSIDE_TESTSUITE)
 #define REQUIRE_BUF_EQ(actual, expected, n)     __TAUCMP_BUF__(actual, expected, n, !=, ==, not equal, REQUIRE_BUF_EQ, TAU_ABORT_IF_INSIDE_TESTSUITE)
 #define REQUIRE_BUF_NE(actual, expected, n)     __TAUCMP_BUF__(actual, expected, n, ==, !=, equal, REQUIRE_BUF_NE, TAU_ABORT_IF_INSIDE_TESTSUITE)
+
+// Pointers Checks
+#define CHECK_PTR_EQ(actual, expected)    __TAUCMP_PTR__(actual, expected, ==, "", CHECK_PTR_EQ, TAU_FAIL_IF_INSIDE_TESTSUITE)
+#define CHECK_PTR_NE(actual, expected)    __TAUCMP_PTR__(actual, expected, !=, "", CHECK_PTR_NE, TAU_FAIL_IF_INSIDE_TESTSUITE)
+#define REQUIRE_PTR_EQ(actual, expected)  __TAUCMP_PTR__(actual, expected, ==, "", REQUIRE_PTR_EQ, TAU_ABORT_IF_INSIDE_TESTSUITE)
+#define REQUIRE_PTR_NE(actual, expected)  __TAUCMP_PTR__(actual, expected, !=, "", REQUIRE_PTR_NE, TAU_ABORT_IF_INSIDE_TESTSUITE)
 
 // Note: The negate sign `!` must be there for {CHECK|REQUIRE}_TRUE
 // Do not remove it


### PR DESCRIPTION
Add pointer comparison macros

Add new macros CHECK_PTR_EQ/NE and REQUIRE_PTR_EQ/NE to simplify pointer comparisons. These macros automatically handle void* casting and use the appropriate %p format specifier for pointer output.

Before:
CHECK_EQ((void*)ptr1, (void*)ptr2);

After:
CHECK_PTR_EQ(ptr1, ptr2);

This change improves code readability while maintaining consistency with the existing CHECK_NULL/NOT_NULL macros. The new macros follow TAU's established pattern and style conventions.