### PR TITLE
fix: --no-summary not recognized as a valid option

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -1077,7 +1077,7 @@ static tau_bool tauCmdLineRead(const int argc, const char* const * const argv) {
         }
 
         // Disable Summary
-        else if(strncmp(argv[i], summaryStr, strlen(summaryStr))) {
+        else if(strncmp(argv[i], summaryStr, strlen(summaryStr)) == 0) {
             tauDisableSummary = 1;
         }
 


### PR DESCRIPTION
Fixed **--no-summary** options not recognized and generating the following error "_Unrecognized option: --no-summary_"