### PR TITLE
Add variadic macro support to pointer assertion macros

### DIFF
--- a/docs/tau-primer.md
+++ b/docs/tau-primer.md
@@ -93,28 +93,6 @@ TEST_F(ExampleTestFixture, EnsureSetupRanBeforeAgain)
 }
 ```
 
-## Ignoring Tests
-
-Sometimes you may want to temporarily disable a test without removing it from the codebase. Tau provides `IGNORE_TEST` and `IGNORE_TEST_F` macros for this purpose.
-
-### Ignoring Regular Tests
-```c
-IGNORE_TEST(TestSuiteName, TestName) {
-    // This test will be skipped during execution
-    CHECK(1 == 2, "This would normally fail but won't run");
-}
-```
-
-### Ignoring Fixture Tests
-```c
-IGNORE_TEST_F(ExampleTestFixture, IgnoredFixtureTest) {
-    // This fixture test will be skipped during execution
-    CHECK(tau->test_variable == 100, "This won't run");
-}
-```
-
-Ignored tests will be displayed with an `[ IGNORED  ]` status when the test suite runs, allowing you to see which tests are currently disabled.
-
 ## Testing Macros
 Tau provides two variants of Assertion Macros - `CHECK`s and `ASSERT`s. These resemble function calls. When these assertions fail, Tau prints the source code location (file + line number) along with a failure message. 
 
@@ -136,8 +114,7 @@ CHECK(result == expected[i], "i=%d", i);
 ```
 
 
-## A List of Available Testing Macros
-
+## A List of Avaliable Testing Macros
 ### a. Basic Assertions
 These assertions perform basic true/false condition checking. 
 
@@ -170,132 +147,24 @@ These macros compare two ***C-strings***.
 | `REQUIRE_SUBSTREQ(str1,str2);`    | `CHECK_SUBSTREQ(str1,str2);`     | the two C strings have the same contents, upto the length of str1   |
 | `REQUIRE_SUBSTRNE(str1,str2);`   | `CHECK_SUBSTRNE(str1,str2);`    | the two C strings have different content, upto the length of str1   |
 
-### d. Buffer Comparisons
-These macros compare memory buffers byte-by-byte using `memcmp`. They are useful for testing binary data, arrays, or structures.
-
-| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
-| --------------------------     | ------------------------------ | -------------------------------------------------------- |
-| `REQUIRE_BUF_EQ(buf1,buf2,n);` | `CHECK_BUF_EQ(buf1,buf2,n);`  | the two memory buffers have identical content for n bytes |
-| `REQUIRE_BUF_NE(buf1,buf2,n);` | `CHECK_BUF_NE(buf1,buf2,n);`  | the two memory buffers have different content within n bytes |
-
-The `n` parameter specifies how many bytes to compare. When a buffer comparison fails, Tau displays the contents in hexadecimal format, highlighting the differences in yellow for easy identification.
-
-### e. Pointer Comparisons
-These macros compare pointer values directly (not the content they point to).
-
-| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
-| --------------------------     | ------------------------------ | -------------------------------------------------------- |
-| `REQUIRE_PTR_EQ(ptr1,ptr2);`   | `CHECK_PTR_EQ(ptr1,ptr2);`     | the two pointers point to the same memory address     |
-| `REQUIRE_PTR_NE(ptr1,ptr2);`   | `CHECK_PTR_NE(ptr1,ptr2);`     | the two pointers point to different memory addresses  |
-
-These are particularly useful for testing pointer assignments, linked data structures, or verifying that functions return the expected pointer values.
-
-### f. NULL Checks
-Convenient macros for checking null pointer values.
-
-| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
-| --------------------------     | ------------------------------ | -------------------------------------------------------- |
-| `REQUIRE_NULL(ptr);`           | `CHECK_NULL(ptr);`             | the pointer is NULL                                    |
-| `REQUIRE_NOT_NULL(ptr);`       | `CHECK_NOT_NULL(ptr);`         | the pointer is not NULL                                |
-
 
 ## Example Usage
-Below is a comprehensive example showing various supported operations:
-
+Below is a slightly contrived example showing a number of possible supported operations:
 ```C
 #include <tau/tau.h>
-#include <string.h>
-
 TAU_MAIN() // sets up Tau 
 
-TEST(BasicTests, ArithmeticOperations) {
+TEST(foo, bar1) {
     int a = 42; 
     int b = 13; 
     CHECK_GE(a, b); // pass :)
     CHECK_LE(b, 8); // fail - Test suite not aborted 
 }
 
-TEST(StringTests, StringComparisons) {
+TEST(foo, bar2) {
     char* a = "foo";
     char* b = "foobar";
-    char* c = "foo";
-    
-    REQUIRE_STREQ(a, c); // pass :) - same content
+    REQUIRE_STREQ(a, a); // pass :)
     REQUIRE_STREQ(a, b); // fail - Test suite aborted :(
-    CHECK_SUBSTREQ(b, a, 3, "First 3 chars should match"); // pass :)
-}
-
-TEST(BufferTests, MemoryComparisons) {
-    unsigned char buffer1[] = {0x01, 0x02, 0x03, 0x04};
-    unsigned char buffer2[] = {0x01, 0x02, 0x03, 0x04};
-    unsigned char buffer3[] = {0x01, 0x02, 0xFF, 0x04};
-    
-    CHECK_BUF_EQ(buffer1, buffer2, 4, "Buffers should be identical");
-    CHECK_BUF_NE(buffer1, buffer3, 4, "Buffers should differ at byte 2");
-}
-
-TEST(PointerTests, PointerComparisons) {
-    int value = 100;
-    int* ptr1 = &value;
-    int* ptr2 = &value;
-    int* ptr3 = NULL;
-    
-    CHECK_PTR_EQ(ptr1, ptr2, "Both pointers should point to same address");
-    CHECK_PTR_NE(ptr1, ptr3, "Pointer should not be NULL");
-    CHECK_NULL(ptr3, "This pointer should be NULL");
-    CHECK_NOT_NULL(ptr1, "This pointer should not be NULL");
-}
-
-// This test will be ignored during execution
-IGNORE_TEST(IgnoredTests, TemporarilyDisabled) {
-    CHECK(1 == 2, "This would fail but won't run");
-}
-
-// Example with test fixture
-struct FileTestFixture {
-    FILE* test_file;
-    char* file_content;
-};
-
-TEST_F_SETUP(FileTestFixture) {
-    tau->test_file = fopen("test.txt", "w+");
-    tau->file_content = malloc(256);
-    strcpy(tau->file_content, "Hello, Tau!");
-    CHECK_NOT_NULL(tau->test_file, "File should be opened successfully");
-}
-
-TEST_F_TEARDOWN(FileTestFixture) {
-    if (tau->test_file) {
-        fclose(tau->test_file);
-    }
-    free(tau->file_content);
-}
-
-TEST_F(FileTestFixture, FileOperations) {
-    // Write to file
-    fprintf(tau->test_file, "%s", tau->file_content);
-    fflush(tau->test_file);
-    
-    // Read back and compare
-    rewind(tau->test_file);
-    char read_buffer[256] = {0};
-    fread(read_buffer, 1, strlen(tau->file_content), tau->test_file);
-    
-    CHECK_STREQ(read_buffer, tau->file_content, "File content should match");
-}
-
-// This fixture test will be ignored
-IGNORE_TEST_F(FileTestFixture, IgnoredFileTest) {
-    // This test won't run but setup/teardown structure is preserved
-    CHECK_STREQ(tau->file_content, "Different content", "This won't execute");
 }
 ```
-
-This example demonstrates:
-- Basic arithmetic checks with custom failure messages
-- String comparison operations (whole strings and substrings)
-- Binary buffer comparisons with hexadecimal output on failure
-- Pointer comparisons and NULL checks
-- Test fixtures with setup and teardown functions
-- How to ignore tests temporarily using `IGNORE_TEST` and `IGNORE_TEST_F`
-- Mixed use of `CHECK` (non-fatal) and `REQUIRE` (fatal) assertions

--- a/docs/tau-primer.md
+++ b/docs/tau-primer.md
@@ -93,6 +93,28 @@ TEST_F(ExampleTestFixture, EnsureSetupRanBeforeAgain)
 }
 ```
 
+## Ignoring Tests
+
+Sometimes you may want to temporarily disable a test without removing it from the codebase. Tau provides `IGNORE_TEST` and `IGNORE_TEST_F` macros for this purpose.
+
+### Ignoring Regular Tests
+```c
+IGNORE_TEST(TestSuiteName, TestName) {
+    // This test will be skipped during execution
+    CHECK(1 == 2, "This would normally fail but won't run");
+}
+```
+
+### Ignoring Fixture Tests
+```c
+IGNORE_TEST_F(ExampleTestFixture, IgnoredFixtureTest) {
+    // This fixture test will be skipped during execution
+    CHECK(tau->test_variable == 100, "This won't run");
+}
+```
+
+Ignored tests will be displayed with an `[ IGNORED  ]` status when the test suite runs, allowing you to see which tests are currently disabled.
+
 ## Testing Macros
 Tau provides two variants of Assertion Macros - `CHECK`s and `ASSERT`s. These resemble function calls. When these assertions fail, Tau prints the source code location (file + line number) along with a failure message. 
 
@@ -114,7 +136,8 @@ CHECK(result == expected[i], "i=%d", i);
 ```
 
 
-## A List of Avaliable Testing Macros
+## A List of Available Testing Macros
+
 ### a. Basic Assertions
 These assertions perform basic true/false condition checking. 
 
@@ -147,24 +170,132 @@ These macros compare two ***C-strings***.
 | `REQUIRE_SUBSTREQ(str1,str2);`    | `CHECK_SUBSTREQ(str1,str2);`     | the two C strings have the same contents, upto the length of str1   |
 | `REQUIRE_SUBSTRNE(str1,str2);`   | `CHECK_SUBSTRNE(str1,str2);`    | the two C strings have different content, upto the length of str1   |
 
+### d. Buffer Comparisons
+These macros compare memory buffers byte-by-byte using `memcmp`. They are useful for testing binary data, arrays, or structures.
+
+| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
+| --------------------------     | ------------------------------ | -------------------------------------------------------- |
+| `REQUIRE_BUF_EQ(buf1,buf2,n);` | `CHECK_BUF_EQ(buf1,buf2,n);`  | the two memory buffers have identical content for n bytes |
+| `REQUIRE_BUF_NE(buf1,buf2,n);` | `CHECK_BUF_NE(buf1,buf2,n);`  | the two memory buffers have different content within n bytes |
+
+The `n` parameter specifies how many bytes to compare. When a buffer comparison fails, Tau displays the contents in hexadecimal format, highlighting the differences in yellow for easy identification.
+
+### e. Pointer Comparisons
+These macros compare pointer values directly (not the content they point to).
+
+| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
+| --------------------------     | ------------------------------ | -------------------------------------------------------- |
+| `REQUIRE_PTR_EQ(ptr1,ptr2);`   | `CHECK_PTR_EQ(ptr1,ptr2);`     | the two pointers point to the same memory address     |
+| `REQUIRE_PTR_NE(ptr1,ptr2);`   | `CHECK_PTR_NE(ptr1,ptr2);`     | the two pointers point to different memory addresses  |
+
+These are particularly useful for testing pointer assignments, linked data structures, or verifying that functions return the expected pointer values.
+
+### f. NULL Checks
+Convenient macros for checking null pointer values.
+
+| Fatal assertion                | Nonfatal assertion             | Checks                                                 |
+| --------------------------     | ------------------------------ | -------------------------------------------------------- |
+| `REQUIRE_NULL(ptr);`           | `CHECK_NULL(ptr);`             | the pointer is NULL                                    |
+| `REQUIRE_NOT_NULL(ptr);`       | `CHECK_NOT_NULL(ptr);`         | the pointer is not NULL                                |
+
 
 ## Example Usage
-Below is a slightly contrived example showing a number of possible supported operations:
+Below is a comprehensive example showing various supported operations:
+
 ```C
 #include <tau/tau.h>
+#include <string.h>
+
 TAU_MAIN() // sets up Tau 
 
-TEST(foo, bar1) {
+TEST(BasicTests, ArithmeticOperations) {
     int a = 42; 
     int b = 13; 
     CHECK_GE(a, b); // pass :)
     CHECK_LE(b, 8); // fail - Test suite not aborted 
 }
 
-TEST(foo, bar2) {
+TEST(StringTests, StringComparisons) {
     char* a = "foo";
     char* b = "foobar";
-    REQUIRE_STREQ(a, a); // pass :)
+    char* c = "foo";
+    
+    REQUIRE_STREQ(a, c); // pass :) - same content
     REQUIRE_STREQ(a, b); // fail - Test suite aborted :(
+    CHECK_SUBSTREQ(b, a, 3, "First 3 chars should match"); // pass :)
+}
+
+TEST(BufferTests, MemoryComparisons) {
+    unsigned char buffer1[] = {0x01, 0x02, 0x03, 0x04};
+    unsigned char buffer2[] = {0x01, 0x02, 0x03, 0x04};
+    unsigned char buffer3[] = {0x01, 0x02, 0xFF, 0x04};
+    
+    CHECK_BUF_EQ(buffer1, buffer2, 4, "Buffers should be identical");
+    CHECK_BUF_NE(buffer1, buffer3, 4, "Buffers should differ at byte 2");
+}
+
+TEST(PointerTests, PointerComparisons) {
+    int value = 100;
+    int* ptr1 = &value;
+    int* ptr2 = &value;
+    int* ptr3 = NULL;
+    
+    CHECK_PTR_EQ(ptr1, ptr2, "Both pointers should point to same address");
+    CHECK_PTR_NE(ptr1, ptr3, "Pointer should not be NULL");
+    CHECK_NULL(ptr3, "This pointer should be NULL");
+    CHECK_NOT_NULL(ptr1, "This pointer should not be NULL");
+}
+
+// This test will be ignored during execution
+IGNORE_TEST(IgnoredTests, TemporarilyDisabled) {
+    CHECK(1 == 2, "This would fail but won't run");
+}
+
+// Example with test fixture
+struct FileTestFixture {
+    FILE* test_file;
+    char* file_content;
+};
+
+TEST_F_SETUP(FileTestFixture) {
+    tau->test_file = fopen("test.txt", "w+");
+    tau->file_content = malloc(256);
+    strcpy(tau->file_content, "Hello, Tau!");
+    CHECK_NOT_NULL(tau->test_file, "File should be opened successfully");
+}
+
+TEST_F_TEARDOWN(FileTestFixture) {
+    if (tau->test_file) {
+        fclose(tau->test_file);
+    }
+    free(tau->file_content);
+}
+
+TEST_F(FileTestFixture, FileOperations) {
+    // Write to file
+    fprintf(tau->test_file, "%s", tau->file_content);
+    fflush(tau->test_file);
+    
+    // Read back and compare
+    rewind(tau->test_file);
+    char read_buffer[256] = {0};
+    fread(read_buffer, 1, strlen(tau->file_content), tau->test_file);
+    
+    CHECK_STREQ(read_buffer, tau->file_content, "File content should match");
+}
+
+// This fixture test will be ignored
+IGNORE_TEST_F(FileTestFixture, IgnoredFileTest) {
+    // This test won't run but setup/teardown structure is preserved
+    CHECK_STREQ(tau->file_content, "Different content", "This won't execute");
 }
 ```
+
+This example demonstrates:
+- Basic arithmetic checks with custom failure messages
+- String comparison operations (whole strings and substrings)
+- Binary buffer comparisons with hexadecimal output on failure
+- Pointer comparisons and NULL checks
+- Test fixtures with setup and teardown functions
+- How to ignore tests temporarily using `IGNORE_TEST` and `IGNORE_TEST_F`
+- Mixed use of `CHECK` (non-fatal) and `REQUIRE` (fatal) assertions

--- a/tau/tau.h
+++ b/tau/tau.h
@@ -713,32 +713,33 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
     tauColouredPrintf(TAU_COLOUR_CYAN_,">");
 }
 
-#define __TAUCMP_PTR__(actual, expected, cond, space, macroName, failOrAbort)                                   \
-    do {                                                                                                        \
-        if(!((void*)(actual)cond(void*)(expected))) {                                                           \
-            tauPrintf("%s:%u: ", __FILE__, __LINE__);                                                           \
-            tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, "FAILED\n");                                               \
-            if(tauShouldDecomposeMacro(#actual, #expected, 0)) {                                                \
-                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "  In macro : ");                                     \
-                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "%s( %s, %s )\n",                                     \
-                                                            #macroName,                                         \
-                                                            #actual, #expected);                                \
-            }                                                                                                   \
-            tauPrintf("  Expected : %s", #actual);                                                              \
-            printf(" %s ", #cond space);                                                                        \
-            printf("%p", (void*)expected);                                                                      \
-            tauPrintf("\n");                                                                                    \
-                                                                                                                \
-            tauPrintf("    Actual : %s", #actual);                                                              \
-            printf(" == ");                                                                                     \
-            printf("%p", (void*)actual);                                                                        \
-            tauPrintf("\n");                                                                                    \
-            failOrAbort;                                                                                        \
-            if(shouldAbortTest) {                                                                               \
-                return;                                                                                         \
-            }                                                                                                   \
-        }                                                                                                       \
-    }                                                                                                           \
+#define __TAUCMP_PTR__(actual, expected, cond, space, macroName, failOrAbort, ...)                  \
+    do {                                                                                            \
+        if(!((void*)(actual)cond(void*)(expected))) {                                               \
+            tauPrintf("%s:%u: ", __FILE__, __LINE__);                                               \
+            tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, __VA_ARGS__);                                  \
+            printf("\n");                                                                           \
+            if(tauShouldDecomposeMacro(#actual, #expected, 0)) {                                    \
+                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "  In macro : ");                         \
+                tauColouredPrintf(TAU_COLOUR_BRIGHTCYAN_, "%s( %s, %s )\n",                         \
+                                                            #macroName,                             \
+                                                            #actual, #expected);                    \
+            }                                                                                       \
+            tauPrintf("  Expected : %s", #actual);                                                  \
+            printf(" %s ", #cond space);                                                            \
+            printf("%p", (void*)expected);                                                          \
+            tauPrintf("\n");                                                                        \
+                                                                                                    \
+            tauPrintf("    Actual : %s", #actual);                                                  \
+            printf(" == ");                                                                         \
+            printf("%p", (void*)actual);                                                            \
+            tauPrintf("\n");                                                                        \
+            failOrAbort;                                                                            \
+            if(shouldAbortTest) {                                                                   \
+                return;                                                                             \
+            }                                                                                       \
+        }                                                                                           \
+    }                                                                                               \
     while(0)
 
 #define __TAUCMP_BUF__(actual, expected, len, cond, ifCondFailsThenPrint, actualPrint, macroName, failOrAbort, ...) \
@@ -853,10 +854,10 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
 #define REQUIRE_BUF_NE_(actual, expected, n, ...)     __TAUCMP_BUF__(actual, expected, n, ==, !=, equal, REQUIRE_BUF_NE, TAU_ABORT_IF_INSIDE_TESTSUITE, __VA_ARGS__)
 
 // Pointers Checks
-#define CHECK_PTR_EQ(actual, expected)    __TAUCMP_PTR__(actual, expected, ==, "", CHECK_PTR_EQ, TAU_FAIL_IF_INSIDE_TESTSUITE)
-#define CHECK_PTR_NE(actual, expected)    __TAUCMP_PTR__(actual, expected, !=, "", CHECK_PTR_NE, TAU_FAIL_IF_INSIDE_TESTSUITE)
-#define REQUIRE_PTR_EQ(actual, expected)  __TAUCMP_PTR__(actual, expected, ==, "", REQUIRE_PTR_EQ, TAU_ABORT_IF_INSIDE_TESTSUITE)
-#define REQUIRE_PTR_NE(actual, expected)  __TAUCMP_PTR__(actual, expected, !=, "", REQUIRE_PTR_NE, TAU_ABORT_IF_INSIDE_TESTSUITE)
+#define CHECK_PTR_EQ_(actual, expected, ...)    __TAUCMP_PTR__(actual, expected, ==, "", CHECK_PTR_EQ, TAU_FAIL_IF_INSIDE_TESTSUITE, __VA_ARGS__)
+#define CHECK_PTR_NE_(actual, expected, ...)    __TAUCMP_PTR__(actual, expected, !=, "", CHECK_PTR_NE, TAU_FAIL_IF_INSIDE_TESTSUITE, __VA_ARGS__)
+#define REQUIRE_PTR_EQ_(actual, expected, ...)  __TAUCMP_PTR__(actual, expected, ==, "", REQUIRE_PTR_EQ, TAU_ABORT_IF_INSIDE_TESTSUITE, __VA_ARGS__)
+#define REQUIRE_PTR_NE_(actual, expected, ...)  __TAUCMP_PTR__(actual, expected, !=, "", REQUIRE_PTR_NE, TAU_ABORT_IF_INSIDE_TESTSUITE, __VA_ARGS__)
 
 // Note: The negate sign `!` must be there for {CHECK|REQUIRE}_TRUE
 // Do not remove it
@@ -894,6 +895,11 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
 #define CHECK_BUF_NE(...)       FIXED3_CHOOSER(__VA_ARGS__)(CHECK_BUF_NE, __VA_ARGS__)
 #define REQUIRE_BUF_EQ(...)     FIXED3_CHOOSER(__VA_ARGS__)(REQUIRE_BUF_EQ, __VA_ARGS__)
 #define REQUIRE_BUF_NE(...)     FIXED3_CHOOSER(__VA_ARGS__)(REQUIRE_BUF_NE, __VA_ARGS__)
+
+#define CHECK_PTR_EQ(...)       FIXED2_CHOOSER(__VA_ARGS__)(CHECK_PTR_EQ, __VA_ARGS__)
+#define CHECK_PTR_NE(...)       FIXED2_CHOOSER(__VA_ARGS__)(CHECK_PTR_NE, __VA_ARGS__)
+#define REQUIRE_PTR_EQ(...)     FIXED2_CHOOSER(__VA_ARGS__)(REQUIRE_PTR_EQ, __VA_ARGS__)
+#define REQUIRE_PTR_NE(...)     FIXED2_CHOOSER(__VA_ARGS__)(REQUIRE_PTR_NE, __VA_ARGS__)
 
 #define CHECK_TRUE(...)         FIXED1_CHOOSER(__VA_ARGS__)(CHECK_TRUE, __VA_ARGS__)
 #define CHECK_FALSE(...)        FIXED1_CHOOSER(__VA_ARGS__)(CHECK_FALSE, __VA_ARGS__)


### PR DESCRIPTION
Extends CHECK_PTR_* and REQUIRE_PTR_* macros to support optional custom error messages with printf-style formatting, bringing them in line with other assertion macros in the framework. This syntax was introduced for the first time here https://github.com/jasmcaus/tau/pull/40 
Added missing documentation as requested here https://github.com/jasmcaus/tau/issues/51 .

## Changes
- Updated existing documentation with description of newly added macros (CHECK_PTR_*, CHECK_BUF_* and IGNORE_TEST)
- Updated `CHECK_PTR_EQ`, `CHECK_PTR_NE`, `REQUIRE_PTR_EQ`, and `REQUIRE_PTR_NE` macros to accept optional printf-formatted messages
- Maintains backward compatibility with existing code
- Consistent interface across all assertion macros

## Usage Examples
```c
// Basic usage (unchanged)
CHECK_PTR_EQ(ptr1, ptr2);
REQUIRE_PTR_NE(ptr1, NULL);

// With custom printf-style messages (new)
CHECK_PTR_EQ(ptr1, ptr2, "Expected pointers to match for %s", test_name);
REQUIRE_PTR_NE(ptr1, NULL, "Pointer should not be NULL at iteration %d", i);