### PR TITLE
Add _Bool support to TAU_OVERLOAD_PRINTER for GCC compatibility

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -528,6 +528,7 @@ static inline int tauShouldDecomposeMacro(const char* const actual, const char* 
     #define TAU_OVERLOAD_PRINTER(val)                         \
         tauPrintf(                                            \
             _Generic((val),                                   \
+                        _Bool : "%d",                         \
                         char : "'%c'",                        \
                         char* : "%s",                         \
                         unsigned char : "%hhu",               \


### PR DESCRIPTION
This PR fixes a compilation error encountered when using GCC (specifically aarch64-linux-gnu-gcc in my case) to assert boolean values.

When using CHECK_EQ (or other macros) on a function returning a bool or a boolean literal, GCC fails to select a matching type in the  _Generic association within TAU_OVERLOAD_PRINTER. This results in the following error:

> error: '_Generic' selector of type '_Bool' is not compatible with any association

This happens because _Bool is a distinct type in C11, and without an explicit entry in the generic selection, it doesn't fall back to int or unsigned int automatically in this context.