### PR TITLE
Fix negative-size-param OOB read in __TAUCMP_BUF__ (CHECK_BUF_EQ/NE)

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -844,6 +844,10 @@ static void tauPrintHexBufCmp(const void* const buff, const void* const ref, con
 
 #define __TAUCMP_BUF__(actual, expected, len, cond, ifCondFailsThenPrint, actualPrint, macroName, failOrAbort, ...) \
     do {                                                                                                        \
+        if(TAU_CAST(int, len) < 0) {                                                                            \
+            tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, "`len` cannot be negative\n");                             \
+            TAU_ABORT;                                                                                          \
+        }                                                                                                       \
         if(memcmp(actual, expected, len) cond 0) {                                                              \
             tauPrintf("%s:%u: ", __FILE__, __LINE__);                                                           \
             tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, __VA_ARGS__);                                              \


### PR DESCRIPTION
## What

`CHECK_BUF_EQ`/`CHECK_BUF_NE`/`REQUIRE_BUF_EQ`/`REQUIRE_BUF_NE` are all built on the `__TAUCMP_BUF__` macro, which passes the caller-supplied `len` straight into `memcmp(actual, expected, len)` with no validation.

If `len` is negative (e.g. computed from a subtraction that underflows, such as `CHECK_BUF_EQ(a, b, lenA - lenB)` where `lenB > lenA`), it gets implicitly converted to a huge `size_t` when passed to `memcmp`, causing an out-of-bounds read.

The sibling macro `__TAUCMP_STRN__` (backing `CHECK_STRN_EQ`/`CHECK_STRN_NE`) already guards its analogous `n` parameter:

```c
if(TAU_CAST(int, n) < 0) {
    tauColouredPrintf(TAU_COLOUR_BRIGHTRED_, "`n` cannot be negative\n");
    TAU_ABORT;
}
```

`__TAUCMP_BUF__` is just missing the equivalent guard for `len`. This PR adds it, mirroring the existing pattern exactly.

## Repro

Compiling a small test with `-fsanitize=address,undefined`:

```c
TEST(neg, buf) {
    char a[4] = {1,2,3,4};
    char b[8] = {0};
    int lenA = 4;
    int lenB = 8;
    CHECK_BUF_EQ(a, b, lenA - lenB); // len = -4
}
```

On the current `dev` HEAD this crashes with:

```
==ERROR: AddressSanitizer: negative-size-param: (size=-4)
```

With this fix applied, it instead aborts cleanly with:

```
`len` cannot be negative
```

## Testing

- Verified the negative-length repro above now fails safely instead of crashing under ASan/UBSan (GCC 13.3.0).
- Compiled and ran the project's own internal test suite (`test/InternalTests/test.c` + `main.c`, unmodified) against both the original and patched header: both report `46 test suites ran, 46 PASSED, 0 failed` — no regressions for any legitimate (non-negative) `CHECK_BUF_*`/`REQUIRE_BUF_*` usage.