### PR TITLE
Fix exact-name test filtering

### DIFF
--- a/tau/tau.h
+++ b/tau/tau.h
@@ -1248,8 +1248,7 @@ static int tauShouldFilterTest(const char* const filter, const char* const testc
             }
         }
 
-        if((*filter_curr != TAU_NULLCHAR) || ((*testcase_curr == TAU_NULLCHAR) && ((filter == filter_curr) ||
-            (filter_curr[-1] != '*')))) {
+        if(*filter_curr != TAU_NULLCHAR) {
             // We have a mismatch
             return 1;
         }

--- a/test/InternalTests/test.c
+++ b/test/InternalTests/test.c
@@ -229,3 +229,7 @@ TEST_F(MyTestF, c2) {
     REQUIRE_EQ(42, tau->foo);
     tau->foo = 13;
 }
+
+TEST(c11, filter_exact_name) {
+    CHECK_EQ(tauShouldFilterTest("c11.filter_exact_name", "c11.filter_exact_name"), 0);
+}


### PR DESCRIPTION
## Problem

`--filter=TEST.NAME` excludes the test when the filter exactly matches its full name. Both cursors reach the string terminator, but the post-loop condition treats that state as a mismatch. Shorter prefixes and wildcard filters already match, which is why removing the last character appears to work.

## Fix

Treat only an unconsumed filter suffix as a mismatch after the scan, and add an internal regression for an exact full-name match.

## Verification

- Real CLI baseline: `--filter=TEST.NAME` runs 0 test suites.
- Fixed CLI: the same filter runs `TEST.NAME` and passes.
- Existing prefix, wildcard, and longer-filter mismatch behavior is unchanged.
- Official CMake/Ninja build completes 29/29 targets.
- Internal suite passes 133/133; third-party 6502 suite passes 362/362.

Fixes #20
